### PR TITLE
Review of PR 1976

### DIFF
--- a/src/kOS/Screen/TermWindow.cs
+++ b/src/kOS/Screen/TermWindow.cs
@@ -1031,6 +1031,7 @@ namespace kOS.Screen
         {
             server.DisconnectFromProcessor();
             telnets.Remove(server);
+            prevTelnetScreens.Remove(server);
         }
         
         public void DetachAllTelnets()

--- a/src/kOS/UserIO/TelnetSingletonServer.cs
+++ b/src/kOS/UserIO/TelnetSingletonServer.cs
@@ -185,7 +185,7 @@ namespace kOS.UserIO
             if (welcomeMenu != null)
             {
                 welcomeMenu.Detach();
-                GameObject.Destroy(welcomeMenu);
+                Object.Destroy(welcomeMenu);
                 welcomeMenu = null;
             }
         }
@@ -383,6 +383,14 @@ namespace kOS.UserIO
             outThread = null; // dispose old thread.
             
             rawStream.Close();
+
+            // Get rid of the welcome menu too, which has a reference to this server and should prevent GC
+            if (welcomeMenu != null)
+            {
+                welcomeMenu.Detach();
+                Object.Destroy(welcomeMenu);
+                welcomeMenu = null;
+            }
         }
 
         public void StartListening()

--- a/src/kOS/Utilities/Utils.cs
+++ b/src/kOS/Utilities/Utils.cs
@@ -283,5 +283,25 @@ namespace kOS.Utilities
             foundId = 0;
             return false;
         }
+
+        /// <summary>
+        /// Displays a popup dialog box with the given title, message, and single "OK" button.
+        /// Use to provide simple information to the user that requires no direct input.
+        /// </summary>
+        /// <param name="title"></param>
+        /// <param name="message"></param>
+        public static void DisplayPopupAlert(string title, string message, params string[] formatArgs)
+        {
+            PopupDialog.SpawnPopupDialog(
+                new MultiOptionDialog(
+                    string.Format(message, formatArgs),
+                    title,
+                    HighLogic.UISkin,
+                    new DialogGUIButton("OK", null, true)
+                    ),
+                true,
+                HighLogic.UISkin
+                );
+        }
     }
 }


### PR DESCRIPTION
I commented each set of changes in individual commits.  Essentially it breaks down to 3 parts:
* Update how `bindAddr` is refreshed - this is relatively minor, just a shift in the logic and location of checking to update `bindAddr` based on a stored string and separate from checking for the server to be enabled.
* Update error handling in cases of invalid IP addresses (either malformed strings in the config file, or an address that isn't available anymore)
* Fix GC of `TelnetSingletonServer`, and verify the finalizer now gets called (though it can still take a minute or two before getting collected)

One last thought: as is an invalid address will display the error dialog the moment that the server tries to start, seconds after KSP loads.  We may want to set the `TelnetMainServer` to start at the Main Menu instead of Instantly.  But I'm not sure it actually matters at all.  I'm inclined to leave things as they are now, but wanted to mention it because it only becomes evident due to these changes.